### PR TITLE
Remove Bold from Dogefont class, re-adds bold to Dogecoin title.

### DIFF
--- a/css/dogecoin.css
+++ b/css/dogecoin.css
@@ -44,7 +44,6 @@ hr {
 		
 .dogefont {
 	font-family: 'Oswald', sans-serif;
-	font-weight: bold;
 }
 
 .btn-circle {

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
 
 <div class="text-center" style="background-color: #f2ede0;">
 	<div style="padding-top: 25px;">
-		<h1 class="dogefont" style="font-size: 5em; line-height: 1em; margin-bottom: 25px;">DOGECOIN</h1>
+		<h1 class="dogefont" style="font-size: 5em; line-height: 1em; margin-bottom: 25px;"><strong>DOGECOIN</strong></h1>
 		<img src="/imgs/dogecoin-300.png" alt="Dogecoin Logo">
 		<h4>Dogecoin is an open source peer-to-peer digital currency, favored by Shiba Inus worldwide.</h4>
 		<!-- Buttons -->


### PR DESCRIPTION
In my opinion, only the Dogecoin title looks okay bolded. Everything else with the Dogefont class doesn't, especially on lower-resolution screens.
