### PR TITLE
Add iOS Wallet Button.

### DIFF
--- a/css/dogecoin.css
+++ b/css/dogecoin.css
@@ -177,3 +177,49 @@ fieldset[disabled] .btn-android.active {
   color: #52C752; 
   background-color: #FFFFFF; 
 }
+
+.btn-ios { 
+  color: #FFFFFF; 
+  background-color: #909499; 
+  border-color: #909499; 
+} 
+ 
+.btn-ios:hover, 
+.btn-ios:focus, 
+.btn-ios:active, 
+.btn-ios.active, 
+.open .dropdown-toggle.btn-ios { 
+  color: #FFFFFF; 
+  background-color: #80858A; 
+  border-color: #909499; 
+} 
+ 
+.btn-ios:active, 
+.btn-ios.active, 
+.open .dropdown-toggle.btn-ios { 
+  background-image: none; 
+} 
+ 
+.btn-ios.disabled, 
+.btn-ios[disabled], 
+fieldset[disabled] .btn-ios, 
+.btn-ios.disabled:hover, 
+.btn-ios[disabled]:hover, 
+fieldset[disabled] .btn-ios:hover, 
+.btn-ios.disabled:focus, 
+.btn-ios[disabled]:focus, 
+fieldset[disabled] .btn-ios:focus, 
+.btn-ios.disabled:active, 
+.btn-ios[disabled]:active, 
+fieldset[disabled] .btn-ios:active, 
+.btn-ios.disabled.active, 
+.btn-ios[disabled].active, 
+fieldset[disabled] .btn-ios.active { 
+  background-color: #909499; 
+  border-color: #909499; 
+} 
+ 
+.btn-ios .badge { 
+  color: #909499; 
+  background-color: #FFFFFF; 
+}

--- a/index.html
+++ b/index.html
@@ -54,6 +54,7 @@
 			<a class="btn btn-md btn-info wallet-button" data-toggle="modal" data-target="#windows-wallet-modal"><span class="fa fa-windows"></span> Windows</a>
 			<a class="btn btn-md btn-default wallet-button" data-toggle="modal" data-target="#osx-wallet-modal"><span class="fa fa-apple"></span> OS X</a> 
 			<a class="btn btn-md btn-primary wallet-button" href="https://github.com/langerhans/multidoge/releases/download/v0.1.2/multidoge-0.1.2-linux.jar"><span class="fa fa-linux"></span> Linux</a>
+			<a class="btn btn-md btn-ios wallet-button" data-toggle="modal" data-target="#ios-wallet-modal"><span class="fa fa-mobile-phone"></span> iOS</a>
 			<a class="btn btn-md btn-android wallet-button" href="https://play.google.com/store/apps/details?id=de.langerhans.wallet" target="_blank"><span class="fa fa-android"></span> Android</a>
 			<a class="btn btn-md btn-blackberry wallet-button" href="http://appworld.blackberry.com/webstore/content/47952864" target="_blank"><span class="icon-blackberry"></span> Blackberry</a>  
 			<a class="btn btn-md btn-warning wallet-button" data-toggle="modal" data-target="#browser-modal"><span class="fa fa-cloud"></span> Browser</a>
@@ -181,6 +182,22 @@
 					<li><a href="https://moolah.io/" target="_blank">Moolah</a></li>
 				</ul>
 				<h5 class="note"><strong>Note:</strong> These online wallets are not owned or maintained by Dogecoin or the Dogecoin Foundation. While we are satisfied they are trustworthy, reliable services - please use at your own risk.</h5>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="modal fade" id="ios-wallet-modal" tabindex="-1" role="dialog" aria-labelledby="ios-wallet-modal-lable" aria-hidden="true">
+	<div class="modal-dialog">
+		<div class="modal-content">
+			<div class="modal-body text-center">
+				<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+				<h2 class="modal-title dogefont" id="browser-modal-lable">IMPORTANT:</h2>
+				<h4>MyDoge for iOS can only be used to view wallets.</h4>
+				<h4>MyDoge <strong>cannot</strong> send Dogecoins. You must set up an actual Dogecoin wallet before you can use this Dogecoin Wallet viewer.</h4>
+				<hr>
+				<a class="btn btn-md btn-primary wallet-button" href="https://itunes.apple.com/app/mydoge/id805178886" target="_blank">I Understand, Let's Go!</a>
+				<h5>Click the button to proceed to the Appstore Page.</h5>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
This pull request adds the iOS Wallet button with a disclaimer-type-of-thing modal when clicked.
How it looks: http://puu.sh/8kBIA.png
Modal: http://puu.sh/8kBJk.png

The "I Understand, Let's Go!" button goes to the MyDoge Appstore Page.
https://itunes.apple.com/app/mydoge/id805178886
