### PR TITLE
Preserve the 'get-started' URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,2 @@
+gems:
+  - jekyll-redirect-from

--- a/getting-started/index.html
+++ b/getting-started/index.html
@@ -1,3 +1,6 @@
+---
+redirect_from: "/get-started/"
+---
 <!DOCTYPE html>
 <html>
 <head>


### PR DESCRIPTION
This is still indexed by search engines and linked from a lot of places. Ran into it Googling for "dogecoin wallet" only to get a 404.
