### PR TITLE
Center Images in Getting Started guide, Adds Note Class to Getting Started CSS.

### DIFF
--- a/css/dogecoin_getstart.css
+++ b/css/dogecoin_getstart.css
@@ -38,6 +38,10 @@ hr {
 	font-family: 'Oswald', sans-serif;
 }
 
+.note {
+    color: #888;
+}
+
 .btn-circle {
 	width: 30px;
 	height: 30px;

--- a/getting-started/index.html
+++ b/getting-started/index.html
@@ -103,7 +103,7 @@
 		<div class="row">
 			<div style="padding-top: 50px;">
 				<div class="col-md-4">
-					<img style="padding-bottom: 30px;" src="../imgs/tut/downloading_dogewallet_windows.jpg" class="img-responsive" alt="Dogecoin Wallet Download" />
+					<img style="padding-bottom: 30px;" src="../imgs/tut/downloading_dogewallet_windows.jpg" class="img-responsive center-block" alt="Dogecoin Wallet Download" />
 				</div>
 				<div class="col-md-8">
 					<h2><strong>1. Download The Wallet.</strong></h2>
@@ -117,7 +117,7 @@
 		<div class="row">
 			<div style="padding-top: 30px;">
 				<div class="col-md-4">
-					<img style="padding-bottom: 30px;" src="../imgs/tut/install_dogewallet_windows.jpg" class="img-responsive" alt="Dogecoin Wallet Install" />
+					<img style="padding-bottom: 30px;" src="../imgs/tut/install_dogewallet_windows.jpg" class="img-responsive center-block" alt="Dogecoin Wallet Install" />
 				</div>
 				<div class="col-md-8">
 					<h2><strong>2. Install The Wallet.</strong></h2>
@@ -130,7 +130,7 @@
 		<div class="row">
 			<div class="padding-top: 50px;">
 				<div class="col-md-4">
-					<img style="padding-bottom: 30px;" src="../imgs/tut/dogewallet_windows.jpg" class="img-responsive" alt="Dogecoin Wallet" />
+					<img style="padding-bottom: 30px;" src="../imgs/tut/dogewallet_windows.jpg" class="img-responsive center-block" alt="Dogecoin Wallet" />
 				</div>
 				<div class="col-md-8">
 					<h2><strong>3. Use Your Wallet!</strong></h2>
@@ -180,7 +180,7 @@
 		<div class="row">
 			<div style="padding-top: 50px;">
 				<div class="col-md-4">
-					<img style="padding-bottom: 30px;" src="../imgs/tut/downloading_dogewallet_osx.jpg" class="img-responsive" alt="Dogecoin Wallet Install" />
+					<img style="padding-bottom: 30px;" src="../imgs/tut/downloading_dogewallet_osx.jpg" class="img-responsive center-block" alt="Dogecoin Wallet Install" />
 				</div>
 				<div class="col-md-8">
 					<h2><strong>1. Download The Wallet.</strong></h2>
@@ -194,7 +194,7 @@
 		<div class="row">
 			<div style="padding-top: 30px;">
 				<div class="col-md-4">
-					<img style="padding-bottom: 30px;" src="../imgs/tut/launch_dogewallet_osx.jpg" class="img-responsive" alt="Dogecoin Wallet Download" />
+					<img style="padding-bottom: 30px;" src="../imgs/tut/launch_dogewallet_osx.jpg" class="img-responsive center-block" alt="Dogecoin Wallet Download" />
 				</div>
 				<div class="col-md-8">
 					<h2><strong>2. Install The Wallet.</strong></h2>
@@ -207,7 +207,7 @@
 		<div class="row">
 			<div class="padding-top: 50px;">
 				<div class="col-md-4">
-					<img style="padding-bottom: 30px;" src="../imgs/tut/dogewallet_osx.jpg" class="img-responsive" alt="Dogecoin Wallet Launch" />
+					<img style="padding-bottom: 30px;" src="../imgs/tut/dogewallet_osx.jpg" class="img-responsive center-block" alt="Dogecoin Wallet Launch" />
 				</div>
 				<div class="col-md-8">
 					<h2><strong>3. Use Your Wallet!</strong></h2>
@@ -257,7 +257,7 @@
 		<div class="row">
 			<div style="padding-top: 50px;">
 				<div class="col-md-4">
-					<img style="padding-bottom: 30px;" src="../imgs/tut/downloading_dogewallet_linux.jpg" class="img-responsive" alt="Dogecoin Wallet Install" />
+					<img style="padding-bottom: 30px;" src="../imgs/tut/downloading_dogewallet_linux.jpg" class="img-responsive center-block" alt="Dogecoin Wallet Install" />
 				</div>
 				<div class="col-md-8">
 					<h2><strong>1. Download The Wallet.</strong></h2>
@@ -271,7 +271,7 @@
 		<div class="row">
 			<div style="padding-top: 30px;">
 				<div class="col-md-4">
-					<img style="padding-bottom: 30px;" src="../imgs/tut/install_dogewallet_linux_01.jpg" class="img-responsive" alt="Dogecoin Wallet Download" />
+					<img style="padding-bottom: 30px;" src="../imgs/tut/install_dogewallet_linux_01.jpg" class="img-responsive center-block" alt="Dogecoin Wallet Download" />
 				</div>
 				<div class="col-md-8">
 					<h2><strong>2. Set Permissions.</strong></h2>
@@ -284,7 +284,7 @@
 		<div class="row">
 			<div style="padding-top: 30px;">
 				<div class="col-md-4">
-					<img style="padding-bottom: 30px;" src="../imgs/tut/install_dogewallet_linux_02.jpg" class="img-responsive" alt="Dogecoin Wallet Download" />
+					<img style="padding-bottom: 30px;" src="../imgs/tut/install_dogewallet_linux_02.jpg" class="img-responsive center-block" alt="Dogecoin Wallet Download" />
 				</div>
 				<div class="col-md-8">
 					<h2><strong>3. Launch as OpenJDK Java!</strong></h2>
@@ -297,7 +297,7 @@
 		<div class="row">
 			<div style="padding-top: 30px;">
 				<div class="col-md-4">
-					<img style="padding-bottom: 30px;" src="../imgs/tut/install_dogewallet_linux_03.jpg" class="img-responsive" alt="Dogecoin Wallet Download" />
+					<img style="padding-bottom: 30px;" src="../imgs/tut/install_dogewallet_linux_03.jpg" class="img-responsive center-block" alt="Dogecoin Wallet Download" />
 				</div>
 				<div class="col-md-8">
 					<h2><strong>4. Install The Wallet.</strong></h2>
@@ -310,7 +310,7 @@
 		<div class="row">
 			<div class="padding-top: 50px;">
 				<div class="col-md-4">
-					<img style="padding-bottom: 30px;" src="../imgs/tut/dogewallet_linux.jpg" class="img-responsive" alt="Dogecoin Wallet Launch" />
+					<img style="padding-bottom: 30px;" src="../imgs/tut/dogewallet_linux.jpg" class="img-responsive center-block" alt="Dogecoin Wallet Launch" />
 				</div>
 				<div class="col-md-8">
 					<h2><strong>5. Use Your Wallet!</strong></h2>
@@ -360,7 +360,7 @@
 		<div class="row">
 			<div style="padding-top: 50px;">
 				<div class="col-md-4">
-					<img style="padding-bottom: 30px;" src="../imgs/tut/install_dogewallet_android.jpg" class="img-responsive" alt="Dogecoin Wallet Download" />
+					<img style="padding-bottom: 30px;" src="../imgs/tut/install_dogewallet_android.jpg" class="img-responsive center-block" alt="Dogecoin Wallet Download" />
 				</div>
 				<div class="col-md-8">
 					<h2><strong>1. Download The Wallet.</strong></h2>
@@ -377,7 +377,7 @@
 		<div class="row">
 			<div style="padding-top: 30px;">
 				<div class="col-md-4">
-					<img style="padding-bottom: 30px;" src="../imgs/tut/launch_dogewallet_android.jpg" class="img-responsive" alt="Dogecoin Wallet Launch" />
+					<img style="padding-bottom: 30px;" src="../imgs/tut/launch_dogewallet_android.jpg" class="img-responsive center-block" alt="Dogecoin Wallet Launch" />
 				</div>
 				<div class="col-md-8">
 					<h2><strong>2. Launch The Wallet.</strong></h2>
@@ -390,7 +390,7 @@
 		<div class="row">
 			<div class="padding-top: 50px;">
 				<div class="col-md-4">
-					<img style="padding-bottom: 30px;" src="../imgs/tut/dogewallet_android.jpg" class="img-responsive" alt="Dogecoin Wallet Launch" />
+					<img style="padding-bottom: 30px;" src="../imgs/tut/dogewallet_android.jpg" class="img-responsive center-block" alt="Dogecoin Wallet Launch" />
 				</div>
 				<div class="col-md-8">
 					<h2><strong>3. Use Your Wallet!</strong></h2>
@@ -440,7 +440,7 @@
 		<div class="row">
 			<div style="padding-top: 50px;">
 				<div class="col-md-4">
-					<img style="padding-bottom: 30px;" src="../imgs/tut/install_dogewallet_ios.jpg" class="img-responsive" alt="Dogecoin Wallet Install" />
+					<img style="padding-bottom: 30px;" src="../imgs/tut/install_dogewallet_ios.jpg" class="img-responsive center-block" alt="Dogecoin Wallet Install" />
 				</div>
 				<div class="col-md-8">
 					<div class="alert alert-danger"><i class="fa fa-warning"></i> <strong>Warning!</strong> MyDoge for iOS can only be used to view wallets. It <strong>cannot</strong> send Dogecoins!</div>
@@ -457,7 +457,7 @@
 		<div class="row">
 			<div style="padding-top: 30px;">
 				<div class="col-md-4">
-					<img style="padding-bottom: 30px;" src="../imgs/tut/download_dogewallet_ios.jpg" class="img-responsive" alt="Dogecoin Wallet Download" />
+					<img style="padding-bottom: 30px;" src="../imgs/tut/download_dogewallet_ios.jpg" class="img-responsive center-block" alt="Dogecoin Wallet Download" />
 				</div>
 				<div class="col-md-8">
 					<h2><strong>2. Wait for the Application to Download.</strong></h2>
@@ -470,7 +470,7 @@
 		<div class="row">
 			<div class="padding-top: 50px;">
 				<div class="col-md-4">
-					<img style="padding-bottom: 30px;" src="../imgs/tut/dogewallet_ios.jpg" class="img-responsive" alt="Dogecoin Wallet Launch" />
+					<img style="padding-bottom: 30px;" src="../imgs/tut/dogewallet_ios.jpg" class="img-responsive center-block" alt="Dogecoin Wallet Launch" />
 				</div>
 				<div class="col-md-8">
 					<h2><strong>3. Use Your Wallet!</strong></h2>
@@ -521,7 +521,7 @@
 		<div class="row">
 			<div style="padding-top: 50px;">
 				<div class="col-md-4">
-					<img style="padding-bottom: 30px;" src="../imgs/tut/dogewallet_signup_01.jpg" class="img-responsive" alt="Dogecoin Wallet Download" />
+					<img style="padding-bottom: 30px;" src="../imgs/tut/dogewallet_signup_01.jpg" class="img-responsive center-block" alt="Dogecoin Wallet Download" />
 				</div>
 				<div class="col-md-8">
 					<div class="alert alert-info"><i class="fa fa-info-circle"></i> <strong>Hold Up!</strong> Do <strong>not</strong> store any large amounts of Dogecoins on the online wallet. It is not safe.</div>
@@ -535,7 +535,7 @@
 		<div class="row">
 			<div style="padding-top: 30px;">
 				<div class="col-md-4">
-					<img style="padding-bottom: 30px;" src="../imgs/tut/dogewallet_signup_02.jpg" class="img-responsive" alt="Dogecoin Wallet Launch" />
+					<img style="padding-bottom: 30px;" src="../imgs/tut/dogewallet_signup_02.jpg" class="img-responsive center-block" alt="Dogecoin Wallet Launch" />
 				</div>
 				<div class="col-md-8">
 					<h2><strong>2. Verify Your Account.</strong></h2>
@@ -548,7 +548,7 @@
 		<div class="row">
 			<div class="padding-top: 50px;">
 				<div class="col-md-4">
-					<img style="padding-bottom: 30px;" src="../imgs/tut/dogewallet_signup_03.jpg" class="img-responsive" alt="Dogecoin Wallet Launch" />
+					<img style="padding-bottom: 30px;" src="../imgs/tut/dogewallet_signup_03.jpg" class="img-responsive center-block" alt="Dogecoin Wallet Launch" />
 				</div>
 				<div class="col-md-8">
 					<h2><strong>3. Use Your Wallet!</strong></h2>
@@ -598,7 +598,7 @@
 		<div class="row">
 			<div style="padding-top: 50px;">
 				<div class="col-md-4">
-					<img style="padding-bottom: 30px;" src="../imgs/tut/dogewallet_moolah_signup_01.jpg" class="img-responsive" alt="Dogecoin Wallet Download" />
+					<img style="padding-bottom: 30px;" src="../imgs/tut/dogewallet_moolah_signup_01.jpg" class="img-responsive center-block" alt="Dogecoin Wallet Download" />
 				</div>
 				<div class="col-md-8">
 					<div class="alert alert-info"><i class="fa fa-info-circle"></i> <strong>Hold Up!</strong> Do <strong>not</strong> store any large amounts of Dogecoins on the online wallet. It is not safe.</div>
@@ -612,7 +612,7 @@
 		<div class="row">
 			<div style="padding-top: 30px;">
 				<div class="col-md-4">
-					<img style="padding-bottom: 30px;" src="../imgs/tut/dogewallet_moolah_signup_02.jpg" class="img-responsive" alt="Dogecoin Wallet Launch" />
+					<img style="padding-bottom: 30px;" src="../imgs/tut/dogewallet_moolah_signup_02.jpg" class="img-responsive center-block" alt="Dogecoin Wallet Launch" />
 				</div>
 				<div class="col-md-8">
 					<h2><strong>2. Create a Dogecoin Account.</strong></h2>
@@ -625,7 +625,7 @@
 		<div class="row">
 			<div class="padding-top: 50px;">
 				<div class="col-md-4">
-					<img style="padding-bottom: 30px;" src="../imgs/tut/dogewallet_moolah_signup_03.jpg" class="img-responsive" alt="Dogecoin Wallet Launch" />
+					<img style="padding-bottom: 30px;" src="../imgs/tut/dogewallet_moolah_signup_03.jpg" class="img-responsive center-block" alt="Dogecoin Wallet Launch" />
 				</div>
 				<div class="col-md-8">
 					<h2><strong>3. Set up your Dogecoin Account.</strong></h2>
@@ -639,7 +639,7 @@
 		<div class="row">
 			<div class="padding-top: 50px;">
 				<div class="col-md-4">
-					<img style="padding-bottom: 30px;" src="../imgs/tut/dogewallet_moolah_signup_04.jpg" class="img-responsive" alt="Dogecoin Wallet Launch" />
+					<img style="padding-bottom: 30px;" src="../imgs/tut/dogewallet_moolah_signup_04.jpg" class="img-responsive center-block" alt="Dogecoin Wallet Launch" />
 				</div>
 				<div class="col-md-8">
 					<h2><strong>4. Use Your Wallet!</strong></h2>

--- a/getting-started/index.html
+++ b/getting-started/index.html
@@ -15,6 +15,7 @@
 	<!-- Meta -->
 	<title>Dogecoin - Getting Started</title>
 	<meta charset="utf-8">
+	<meta content="Getting Started with Dogecoin is as easy as 1, 2, 3! It's simple, easy to set up, and free." name="description">
 	<meta content="width=device-width, initial-scale=1.0" name="viewport">
 	
 	<!-- Scripts -->
@@ -146,7 +147,7 @@
 			<footer>
 				<div class="text-center">
 					<div class="row">
-						<h1><strong>Congratulations!</strong> Now let's put them to good use.</h1>
+						<h1><strong>Congratulations!</strong> Now let's put it to good use.</h1>
 								
 						<div style="padding-top: 15px;">
 							<div class="col-md-4">
@@ -223,7 +224,7 @@
 			<footer>
 				<div class="text-center">
 					<div class="row">
-						<h1><strong>Congratulations!</strong> Now let's put them to good use.</h1>
+						<h1><strong>Congratulations!</strong> Now let's put it to good use.</h1>
 								
 						<div style="padding-top: 15px;">
 							<div class="col-md-4">
@@ -326,7 +327,7 @@
 			<footer>
 				<div class="text-center">
 					<div class="row">
-						<h1><strong>Congratulations!</strong> Now let's put them to good use.</h1>
+						<h1><strong>Congratulations!</strong> Now let's put it to good use.</h1>
 								
 						<div style="padding-top: 15px;">
 							<div class="col-md-4">
@@ -406,7 +407,7 @@
 			<footer>
 				<div class="text-center">
 					<div class="row">
-						<h1><strong>Congratulations!</strong> Now let's put them to good use.</h1>
+						<h1><strong>Congratulations!</strong> Now let's put it to good use.</h1>
 								
 						<div style="padding-top: 15px;">
 							<div class="col-md-4">
@@ -487,7 +488,7 @@
 			<footer>
 				<div class="text-center">
 					<div class="row">
-						<h1><strong>Congratulations!</strong> Now let's put them to good use.</h1>
+						<h1><strong>Congratulations!</strong> Now let's put it to good use.</h1>
 								
 						<div style="padding-top: 15px;">
 							<div class="col-md-4">
@@ -564,7 +565,7 @@
 			<footer>
 				<div class="text-center">
 					<div class="row">
-						<h1><strong>Congratulations!</strong> Now let's put them to good use.</h1>
+						<h1><strong>Congratulations!</strong> Now let's put it to good use.</h1>
 								
 						<div style="padding-top: 15px;">
 							<div class="col-md-4">
@@ -655,7 +656,7 @@
 			<footer>
 				<div class="text-center">
 					<div class="row">
-						<h1><strong>Congratulations!</strong> Now let's put them to good use.</h1>
+						<h1><strong>Congratulations!</strong> Now let's put it to good use.</h1>
 								
 						<div style="padding-top: 15px;">
 							<div class="col-md-4">

--- a/index.html
+++ b/index.html
@@ -341,7 +341,7 @@
 								<h4>MultiDoge is a light wallet, so it only needs to "skim" through the blockchain before it becomes usable. This is done quickly.</h4>
 								<h4>But the wallet should only be for normal use. It <strong>cannot</strong> be used to mine Dogecoin, as the wallet will become slow and unresponsive if used this way.</h4>
 								<h4>Dogecoin Core on the other hand, downloads the entire blockchain. Its initial sync is significantly slower compared to MultiDoge, and it takes up a lot more space.</h4>
-								<h4>But this comes at an advantage. It is safe to mine Dogecoin with this wallet, as it will be able to handle the transactions from payouts.</h4>
+								<h4>But this comes at an advantage. It is safe to mine Dogecoin with this wallet, as it will be able to handle the transactions from payouts. It will also help maintain the Dogecoin network.</h4>
 							</div>
 						</div>
 					</div>
@@ -400,7 +400,7 @@
 								<h4>MultiDoge is a light wallet, so it only needs to "skim" through the blockchain before it becomes usable. This is done quickly.</h4>
 								<h4>But the wallet should only be for normal use. It <strong>cannot</strong> be used to mine Dogecoin, as the wallet will become slow and unresponsive if used this way.</h4>
 								<h4>Dogecoin Core on the other hand, downloads the entire blockchain. Its initial sync is significantly slower compared to MultiDoge, and it takes up a lot more space.</h4>
-								<h4>But this comes at an advantage. It is safe to mine Dogecoin with this wallet, as it will be able to handle the transactions from payouts.</h4>
+								<h4>But this comes at an advantage. It is safe to mine Dogecoin with this wallet, as it will be able to handle the transactions from payouts. It will also help maintain the Dogecoin network.</h4>
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
This Pull Request adds the "Center-block" class from Bootstrap to the images to put them in the center. It also adds the Note class to color the disclaimer in the Buttons on the bottom grey.

Example of Centered Image:
Before: http://puu.sh/8pvRR.png
After: http://puu.sh/8pvSm.png

Grey Disclaimer:
Before: http://puu.sh/8pvWm.png
After: http://puu.sh/8pvVB.png

Also on the buttons, changed the title "Congratulations! Now let's put **them** to good use." to "Congratulations! Now let's put **it** to good use." And added a meta description.

Edit: It also adds to the Dogecoin Wallet modals in the Advantages and Disadvantages section "It will also help maaintain the Dogecoin network."
