### PR TITLE
Changes Forum in Community Section to Discuss Dogecoin.

### DIFF
--- a/getting-started/index.html
+++ b/getting-started/index.html
@@ -698,7 +698,7 @@
 					<li><a href="http://www.reddit.com/r/dogecoin" target="_blank">Reddit Community</a> - The Main Hotspot of the Dogecoin Community.</li>
 					<li><a href="http://foundation.dogecoin.com/" target="_blank">Dogecoin Foundation</a> - Non-Profit Organization which uses Dogecoin for goodwill and charitable endeavors.</li>
 					<li><a href="http://webchat.freenode.net/?nick=Shibe..&amp;channels=%23dogecoin&amp;prompt=1" target="_blank">#dogecoin IRC</a> - Dogecoin-based Internet Chat.</li>
-					<li><a href="http://doges.org/" target="_blank">Doges.org</a> - Dogecoin Forums.</li>
+					<li><a href="http://discuss.dogecoin.com/" target="_blank">Discuss Dogecoin</a> - Dogecoin Forums.</li>
 				</ul>
 				<h5>We are friendly, and we will be happy to answer any Dogecoin-related questions. <br/>Try us, we promise we won't bite!</h5>
 			</div>

--- a/index.html
+++ b/index.html
@@ -237,7 +237,7 @@
 					<li><a href="http://www.reddit.com/r/dogecoin" target="_blank">Reddit Community</a> - The Main Hotspot of the Dogecoin Community.</li>
 					<li><a href="http://foundation.dogecoin.com/" target="_blank">Dogecoin Foundation</a> - Non-Profit Organization which uses Dogecoin for goodwill and charitable endeavors.</li>
 					<li><a href="http://webchat.freenode.net/?nick=Shibe..&amp;channels=%23dogecoin&amp;prompt=1" target="_blank">#dogecoin IRC</a> - Dogecoin-based Internet Chat.</li>
-					<li><a href="http://doges.org/" target="_blank">Doges.org</a> - Dogecoin Forums.</li>
+					<li><a href="http://discuss.dogecoin.com/" target="_blank">Discuss Dogecoin</a> - Dogecoin Forums.</li>
 				</ul>
 				<h5>We are friendly, and we will be happy to answer any Dogecoin-related questions. <br/>Try us, we promise we won't bite!</h5>
 			</div>


### PR DESCRIPTION
As title, this PR changes the forum in the community section from Doges.org (http://doges.org/) to Discuss Dogecoin (http://discuss.dogecoin.com/).
