### PR TITLE
Fix broken Dogechain Wallet Link

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,7 +180,7 @@
 				<h5>Online wallets are the quickest and easiest way to use Dogecoin, but lack the security of storing your wallet on your local computer. <br/><br/>We recommend you only store a small amount of Dogecoin in an online wallet at any time. <br/>There are several secure, browser-based wallets available to choose from:</h5>
 				<ul>
 					<li><a href="https://www.dogevault.com/" target="_blank">DogeVault</a></li>
-					<li><a href="https://secure.dogechain.info/wallet" target="_blank">DogeChain Wallet</a></li>
+					<li><a href="https://dogechain.info/wallet" target="_blank">DogeChain Wallet</a></li>
 					<li><a href="https://www.dogeapi.com/" target="_blank">DogeAPI</a></li>
 					<li><a href="https://moolah.io/" target="_blank">Moolah</a></li>
 				</ul>


### PR DESCRIPTION
The link to the Dogechain Wallet was broken. It seems to have changed from https://secure.dogechain.info/wallet to https://dogechain.info/wallet. This fixes that issue.
