### PR TITLE
Replaces MyDoge with Dogekeeper

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,10 +200,9 @@
 			<div class="modal-body text-center">
 				<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
 				<h2 class="modal-title dogefont" id="ios-wallet-modal-lable">IMPORTANT:</h2>
-				<h4>MyDoge for iOS can only be used to view wallets.</h4>
-				<h4>MyDoge <strong>cannot</strong> send Dogecoins. You must set up an actual Dogecoin wallet before you can use this Dogecoin Wallet viewer.</h4>
+				<h4>Dogekeeper for iOS can be used to send & receive Dogecoin but you must have a <a href="https://www.dogeapi.com/">DogeAPI</a> account first.</h4>
 				<hr>
-				<a class="btn btn-md btn-primary wallet-button" href="https://itunes.apple.com/app/mydoge/id805178886" target="_blank">I Understand, Let's Go!</a>
+				<a class="btn btn-md btn-primary wallet-button" href="https://itunes.apple.com/app/dogekeeper/id889806231?1" target="_blank">I Understand, Let's Go!</a>
 				<h5>Click the button to proceed to the Appstore Page.</h5>
 			</div>
 		</div>

--- a/index.html
+++ b/index.html
@@ -202,7 +202,7 @@
 				<h2 class="modal-title dogefont" id="ios-wallet-modal-lable">IMPORTANT:</h2>
 				<h4>Dogekeeper for iOS can be used to send & receive Dogecoin but you must have a <a href="https://www.dogeapi.com/">DogeAPI</a> account first.</h4>
 				<hr>
-				<a class="btn btn-md btn-primary wallet-button" href="https://itunes.apple.com/app/dogekeeper/id889806231?1" target="_blank">I Understand, Let's Go!</a>
+				<a class="btn btn-md btn-primary wallet-button" href="https://itunes.apple.com/app/dogekeeper/id889806231" target="_blank">I Understand, Let's Go!</a>
 				<h5>Click the button to proceed to the Appstore Page.</h5>
 			</div>
 		</div>


### PR DESCRIPTION
Replaces the current non-wallet link with [Dogekeeper](https://itunes.apple.com/app/dogekeeper/id889806231), which can be used to send and receive Dogecoins thanks to the DogeAPI service.
