### PR TITLE
Change Moolah URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,7 +187,7 @@
 					<li><a href="https://my.dogechain.info/#/overview" target="_blank">DogeChain Wallet</a></li>
 					<li><a href="https://holytransaction.com/" target="_blank">HolyTransaction</a></li>
 					<li><a href="https://www.dogeapi.com/" target="_blank">DogeAPI</a></li>
-					<li><a href="https://v2.moolah.io/" target="_blank">Moolah</a></li>
+					<li><a href="https://moolah.io/" target="_blank">Moolah</a></li>
 				</ul>
 				<h5 class="note"><strong>Note:</strong> These online wallets are not owned or maintained by Dogecoin or the Dogecoin Foundation. While we think the entities behind them are trustworthy - please use at your own risk.</h5>
 			</div>


### PR DESCRIPTION
The v2 is no longer necessary and has a red reputation in WOT.
