### PR TITLE
Change logo attribution url

### DIFF
--- a/i18n/de.json
+++ b/i18n/de.json
@@ -53,7 +53,7 @@
     "dgc-get-dogecoin-how": "Finde heraus, wie man Dogecoin erh&auml;lt.", 
     "dgc-stores-title": "Gesch&auml;fte.",
     "dgc-stores-buy": "Etwas mit Dogecoin kaufen.",
-    "dgc-footer-credits": "Erschaffen von <a href=\"http://www.ummjackson.com\" target=\"_blank\">Jackson Palmer</a> & <a href=\"https://twitter.com/BillyM2k\" target=\"_blank\">Shibetoshi Nakamoto</a>. Design von <a href=\"http://steamcommunity.com/id/powerlemonz\" target=\"_blank\">PowerLemons</a>. Logo von <a href=\"https://twitter.com/christinericks\" target=\"_blank\">Christine Ricks</a>.",
+    "dgc-footer-credits": "Erschaffen von <a href=\"http://www.ummjackson.com\" target=\"_blank\">Jackson Palmer</a> & <a href=\"https://twitter.com/BillyM2k\" target=\"_blank\">Shibetoshi Nakamoto</a>. Design von <a href=\"http://steamcommunity.com/id/powerlemonz\" target=\"_blank\">PowerLemons</a>. Logo von <a href=\"http://christinemix.com\" target=\"_blank\">Christine Ricks</a>.",
     "dgc-footer-copyright": "© The &#208;ogecoin Project",
     "dgc-browser-modal-title": "SUCHE EINE \"BRIEFTASCHE\" AUS:",
     "dgc-browser-modal-online": "Online-\"Brieftaschen\" sind der schnellste und einfachste Weg, Dogecoin zu benutzen, allerdings fehlt ihnen die Sicherheit der Speicherung der Brieftasche auf deinem lokalen Computer.  <br /><br />Wir empfehlen, nur eine kleine Menge an Dogecoin in einer Online-Brieftasche zu behalten. <br />Es gibt einige Online-Brieftaschen, aus denen du w&auml;hlen kannst:",

--- a/i18n/doge.json
+++ b/i18n/doge.json
@@ -53,7 +53,7 @@
     "dgc-get-dogecoin-how": "Find out how to get Dogecoin.",
     "dgc-stores-title": "Stores.", 
     "dgc-stores-buy": "Buy with Dogecoin.",
-    "dgc-footer-credits": "created by <a href=\"http://www.ummjackson.com\" target=\"_blank\">Jackson Palmer</a> <a href=\"https://twitter.com/BillyM2k\" target=\"_blank\">Shibetoshi Nakamoto</a>, website design by <a href=\"http://steamcommunity.com/id/powerlemonz\" target=\"_blank\">PowerLemons</a>, logo by <a href=\"https://twitter.com/christinericks\" target=\"_blank\">Christine Ricks</a>", 
+    "dgc-footer-credits": "created by <a href=\"http://www.ummjackson.com\" target=\"_blank\">Jackson Palmer</a> <a href=\"https://twitter.com/BillyM2k\" target=\"_blank\">Shibetoshi Nakamoto</a>, website design by <a href=\"http://steamcommunity.com/id/powerlemonz\" target=\"_blank\">PowerLemons</a>, logo by <a href=\"http://christinemix.com\" target=\"_blank\">Christine Ricks</a>",
     "dgc-footer-copyright": "© The Ðogecoin Project", 
     "dgc-browser-modal-title": "CHOOSE AN ONLINE WALLET:", 
     "dgc-browser-modal-online": "Online wallets are the quickest and easiest way to use Dogecoin, but lack the security of storing your wallet on your local computer. <br /><br />We recommend you only store a small amount of Dogecoin in an online wallet at any time. <br />There are several browser-based wallets available to choose from:",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -53,7 +53,7 @@
     "dgc-get-dogecoin-how": "Find out how to get Dogecoin.",
     "dgc-stores-title": "Stores.", 
     "dgc-stores-buy": "Buy with Dogecoin.",
-    "dgc-footer-credits": "Created by <a href=\"http://www.ummjackson.com\" target=\"_blank\">Jackson Palmer</a> & <a href=\"https://twitter.com/BillyM2k\" target=\"_blank\">Shibetoshi Nakamoto</a>. Website Design by <a href=\"http://steamcommunity.com/id/powerlemonz\" target=\"_blank\">PowerLemons</a>. Logo by <a href=\"https://twitter.com/christinericks\" target=\"_blank\">Christine Ricks</a>.", 
+    "dgc-footer-credits": "Created by <a href=\"http://www.ummjackson.com\" target=\"_blank\">Jackson Palmer</a> & <a href=\"https://twitter.com/BillyM2k\" target=\"_blank\">Shibetoshi Nakamoto</a>. Website Design by <a href=\"http://steamcommunity.com/id/powerlemonz\" target=\"_blank\">PowerLemons</a>. Logo by <a href=\"http://christinemix.com\" target=\"_blank\">Christine Ricks</a>.",
     "dgc-footer-copyright": "© The Ðogecoin Project", 
     "dgc-browser-modal-title": "CHOOSE AN ONLINE WALLET:", 
     "dgc-browser-modal-online": "Online wallets are the quickest and easiest way to use Dogecoin, but lack the security of storing your wallet on your local computer. <br /><br />We recommend you only store a small amount of Dogecoin in an online wallet at any time. <br />There are several browser-based wallets available to choose from:",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -53,7 +53,7 @@
     "dgc-get-dogecoin-how": "Découvrez comment obtenir des Dogecoins.",
     "dgc-stores-title": "Commerces.", 
     "dgc-stores-buy": "Achetez en Dogecoins.",
-    "dgc-footer-credits": "Créé par <a href=\"http://www.ummjackson.com\" target=\"_blank\">Jackson Palmer</a> <a href=\"https://twitter.com/BillyM2k\" target=\"_blank\">Shibetoshi Nakamoto</a>, design du site par <a href=\"http://steamcommunity.com/id/powerlemonz\" target=\"_blank\">PowerLemons</a>, logo par <a href=\"https://twitter.com/christinericks\" target=\"_blank\">Christine Ricks</a>", 
+    "dgc-footer-credits": "Créé par <a href=\"http://www.ummjackson.com\" target=\"_blank\">Jackson Palmer</a> <a href=\"https://twitter.com/BillyM2k\" target=\"_blank\">Shibetoshi Nakamoto</a>, design du site par <a href=\"http://steamcommunity.com/id/powerlemonz\" target=\"_blank\">PowerLemons</a>, logo par <a href=\"http://christinemix.com\" target=\"_blank\">Christine Ricks</a>",
     "dgc-footer-copyright": "© Le Projet Ðogecoin", 
     "dgc-browser-modal-title": "CHOISISSEZ UN PORTEFEUILLE EN LIGNE :", 
     "dgc-browser-modal-online": "Les portefeuilles en ligne sont le moyen le plus rapide et facile d'utiliser le Dogecoin mais ceux-ci manquent de sécurité car votre portefeuille n'est pas stocké directement sur votre ordinateur. <br/><br/>Il est recommandé de ne seulement garder qu'une petite quantité de Dogecoins sur un portefeuille en ligne. <br/>Vous pouvez choisir parmi ces portefeuilles en ligne :",

--- a/index.html
+++ b/index.html
@@ -192,7 +192,7 @@
 				
 			</div>
 			<hr>
-			<h5 data-i18n="dgc-footer-credits">Created by <a href="http://www.ummjackson.com" target="_blank">Jackson Palmer</a> &amp; <a href="https://twitter.com/BillyM2k" target="_blank">Shibetoshi Nakamoto</a>. Website Design by <a href="http://steamcommunity.com/id/powerlemonz" target="_blank">PowerLemons</a>. Logo by <a href="https://twitter.com/christinericks" target="_blank">Christine Ricks</a>.</h5>
+			<h5 data-i18n="dgc-footer-credits">Created by <a href="http://www.ummjackson.com" target="_blank">Jackson Palmer</a> &amp; <a href="https://twitter.com/BillyM2k" target="_blank">Shibetoshi Nakamoto</a>. Website Design by <a href="http://steamcommunity.com/id/powerlemonz" target="_blank">PowerLemons</a>. Logo by <a href="http://christinemix.com" target="_blank">Christine Ricks</a>.</h5>
 			<h5 data-i18n="dgc-footer-copyright">© The Ðogecoin Project</h5>
 		</div>
 	</footer>


### PR DESCRIPTION
Christine requested to change the attribution url for the logo from her twitter, to her portfolio, while we were discussing matters regarding licensing and attribution, quoted:

>  I really appreciate being attributed on the official Dogecoin site (though it would be cool if the link went to my portfolio christinemix.com rather than my Twitter). 

Hereby :)
