### PR TITLE
Disable dogeoutlet.com

### DIFF
--- a/getting-started/index.html
+++ b/getting-started/index.html
@@ -759,7 +759,7 @@ redirect_from: "/get-started/"
 				<h5><span data-i18n="dgc-stores-modal-shop-online">You can shop for goods online with Dogecoin. </span><br/><br/><span data-i18n="dgc-stores-modal-sale">Dogecoin is safe during checkout, because you don't put down any sensitive bank information! Just send your Dogecoin to the address specified by the merchant, and then you'll have your item processed and ready for delivery in an instant! </span><br/><br/><span data-i18n="dgc-stores-modal-businesses">Here are some businesses that accept Dogecoin:</span></h5>
 				<ul>
 					<li><a data-i18n="dgc-stores-modal-bitcoinshop" href="http://www.bitcoinshop.us/" target="_blank">BitcoinShop.us</a></li>
-					<li><a data-i18n="dgc-stores-modal-dogeoutlet" href="https://dogeoutlet.com/" target="_blank">DogeOutlet</a></li>
+					<!--<li><a data-i18n="dgc-stores-modal-dogeoutlet" href="https://dogeoutlet.com/" target="_blank">DogeOutlet</a></li>-->
 				</ul>
 				<h5 data-i18n="dgc-stores-modal-directories">If that isn't enough, you can look at the Dogecoin Business Directories below.</h5>
 				<h5><a data-i18n="dgc-stores-modal-dogedir" href="http://dogedir.com/" target="_blank">Dogedir</a><span data-i18n="dgc-stores-modal-dogedir-desc"> - Dogecoin Business Directory.</span><br><a data-i18n="dgc-stores-modal-dogecoin-link" href="http://dogecoin.link/" target="_blank">Dogecoin.link</a><span data-i18n="dgc-stores-modal-dogecoin-link-desc"> - User-generated Dogecoin Directory.</span></h5>

--- a/index.html
+++ b/index.html
@@ -290,7 +290,7 @@
 				<h5><span data-i18n="dgc-stores-modal-shop-online">You can shop for goods online with Dogecoin. </span><br/><br/><span data-i18n="dgc-stores-modal-sale">Dogecoin is safe during checkout, because you don't put down any sensitive bank information! Just send your Dogecoin to the address specified by the merchant, and then you'll have your item processed and ready for delivery in an instant! </span><br/><br/><span data-i18n="dgc-stores-modal-businesses">Here are some businesses that accept Dogecoin:</span></h5>
 				<ul>
 					<li><a data-i18n="dgc-stores-modal-bitcoinshop" href="http://www.bitcoinshop.us/" target="_blank">BitcoinShop.us</a></li>
-					<li><a data-i18n="dgc-stores-modal-dogeoutlet" href="https://dogeoutlet.com/" target="_blank">DogeOutlet</a></li>
+					<!-- <li><a data-i18n="dgc-stores-modal-dogeoutlet" href="https://dogeoutlet.com/" target="_blank">DogeOutlet</a></li> -->
 				</ul>
 				<h5 data-i18n="dgc-stores-modal-directories">If that isn't enough, you can look at the Dogecoin Business Directories below.</h5>
 				<h5><a data-i18n="dgc-stores-modal-dogedir" href="http://dogedir.com/" target="_blank">Dogedir</a><span data-i18n="dgc-stores-modal-dogedir-desc"> - Dogecoin Business Directory.</span><br><a data-i18n="dgc-stores-modal-dogecoin-link" href="http://dogecoin.link/" target="_blank">Dogecoin.link</a><span data-i18n="dgc-stores-modal-dogecoin-link-desc"> - User-generated Dogecoin Directory.</span></h5>


### PR DESCRIPTION
The dogeoutlet.com site has been broken for a while now.

Many thanks to the mysterious shibe "fidelis" who frequently emails the Foundation pointing out issues with the dogecoin.com site, including this one. :)
