### PR TITLE
update core download links to 1.10.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -317,10 +317,10 @@
 					</div>
 					<div class="col-md-6">
 						<img src="/imgs/dogecoin-300.png" width="150" height="150" alt="Dogecoin Core">
-						<a href="https://github.com/dogecoin/dogecoin/releases/download/v1.8.2/dogecoin-1.8.2-win32-setup.exe">
+						<a href="https://github.com/dogecoin/dogecoin/releases/download/v1.10.0/dogecoin-1.10.0-win32-setup-unsigned.exe">
 							<h4 data-i18n="dgc-windows-wallet-modal-dogecoin-core-32bit">Dogecoin Core. (32 bit)</h4>
 						</a>
-						<a href="https://github.com/dogecoin/dogecoin/releases/download/v1.8.2/dogecoin-1.8.2-win64-setup.exe">
+						<a href="https://github.com/dogecoin/dogecoin/releases/download/v1.10.0/dogecoin-1.10.0-win64-setup-unsigned.exe">
 							<h4 data-i18n="dgc-windows-wallet-modal-dogecoin-core-64bit">Dogecoin Core. (64 bit)</h4>
 						</a>
 						<h5 data-i18n="dgc-windows-wallet-modal-dogecoin-core-desc">The Dogecoin "Full" Wallet.</h5>
@@ -382,7 +382,7 @@
 					</div>
 					<div class="col-md-6">
 						<img src="/imgs/dogecoin-300.png" width="150" height="150" alt="Dogecoin Core">
-						<a href="https://github.com/dogecoin/dogecoin/releases/download/v1.8.2/dogecoin-1.8.2-mac.zip">
+						<a href="https://github.com/dogecoin/dogecoin/releases/download/v1.10.0/dogecoin-1.10.0-osx-signed.dmg">
 							<h4 data-i18n="dgc-osx-wallet-modal-dogecoin-core">Dogecoin Core.</h4>
 						</a>
 						<h5 data-i18n="dgc-windows-wallet-modal-dogecoin-core-desc">The Dogecoin "Full" Wallet.</h5>
@@ -444,10 +444,10 @@
 					</div>
 					<div class="col-md-6">
 						<img src="/imgs/dogecoin-300.png" width="150" height="150" alt="Dogecoin Core">
-						<a href="https://github.com/dogecoin/dogecoin/releases/download/v1.8.2/dogecoin-1.8.2-linux32.zip">
+						<a href="https://github.com/dogecoin/dogecoin/releases/download/v1.10.0/dogecoin-1.10.0-linux32.tar.gz">
 							<h4 data-i18n="dgc-windows-wallet-modal-dogecoin-core-32bit">Dogecoin Core. (32 bit)</h4>
 						</a>
-						<a href="https://github.com/dogecoin/dogecoin/releases/download/v1.8.2/dogecoin-1.8.2-linux64.zip">
+						<a href="https://github.com/dogecoin/dogecoin/releases/download/v1.10.0/dogecoin-1.10.0-linux64.tar.gz">
 							<h4 data-i18n="dgc-windows-wallet-modal-dogecoin-core-64bit">Dogecoin Core. (64 bit)</h4>
 						</a>
 						<h5 data-i18n="dgc-windows-wallet-modal-dogecoin-core-desc">The Dogecoin "Full" Wallet.</h5>


### PR DESCRIPTION
links taken from https://github.com/dogecoin/dogecoin/releases/tag/v1.10.0
