### PR TITLE
restored exchanges section, added a link to price comparison

### DIFF
--- a/index.html
+++ b/index.html
@@ -265,10 +265,10 @@
 					<li><a data-i18n="dgc-exchanges-modal-dogefaucet" href="http://www.dogefaucet.com/" target="_blank">Dogefaucet.com</a><span data-i18n="dgc-exchanges-modal-dogefaucet-desc"> - Enter your address to get some free Dogecoin.</span></li>
 					<li><a data-i18n="dgc-exchanges-modal-indogewetrust" href="http://indogewetrust.com/" target="_blank">InDogeWeTrust.com</a><span data-i18n="dgc-exchanges-modal-indogewetrust-desc"> - Same as Dogefaucet.</span></li>
 				</ul>
-				<!--<h5><span data-i18n="dgc-exchanges-modal-exchanges">You can also buy them or exchange for them with regular money. This is an easy way to get Dogecoin. </span><br/><br/><span data-i18n="dgc-exchanges-modal-list">Here are some trusted Dogecoin exchanges:</span></h5>
+				<h5><span data-i18n="dgc-exchanges-modal-exchanges">You can also buy them or exchange for them with regular money. This is an easy way to get Dogecoin. </span><br/><br/><span data-i18n="dgc-exchanges-modal-list">Here are some trusted Dogecoin exchanges:</span></h5>
 				<ul>
-					<li><a data-i18n="dgc-exchanges-modal-weselldoge" href="https://www.weselldoges.com/" target="_blank">WeSellDoges</a><span data-i18n="dgc-exchanges-modal-weselldoge-desc"> (PayPal)</span></li>
-				</ul>-->
+					<li><a data-i18n="dgc-exchanges-modal-exchangeratespro" href="https://exchangerates.pro/?to_currency=DOGE" target="_blank">ExchangeRates.Pro</a><span data-i18n="dgc-exchanges-modal-exchangeratespro-desc"> price comparison of DOGE at the exchanges and brokers worldwide</span></li>
+				</ul>
 				<h5><span data-i18n="dgc-exchanges-modal-mining">You can also get Dogecoin by "mining" it. Mining is when you use your computer to process Dogecoin transactions by other people, and in return you get Dogecoin. </span><br/><br/><span data-i18n="dgc-exchanges-modal-mining-howto">Mining is intended for advanced users only, as it requires a lot of technical knowledge to do. If you are interested, <a href="http://dogecointutorial.com/mining.html" target="_blank">read more here</a>.</span></h5>
 				<h5 data-i18n="dgc-exchanges-modal-disclaimer" class="note"><strong>Note:</strong> These online faucets and exchanges are not owned or maintained by Dogecoin. While we are satisfied they are trustworthy, reliable services - please use at your own risk.</h5>
 			</div>


### PR DESCRIPTION
I propose to add a link https://exchangerates.pro/?to_currency=DOGE that will prepare all the possible ways to buy DOGE in the user country and local currency, if possible. Our platform helps the user to find the most profitable and safe way to buy, sell, and exchange crypto in 255 countries comparing Exchanges, Brokers and the P2P Market. We believe it will be useful. Thanks!