### PR TITLE
Update Android APK download link

### DIFF
--- a/i18n/de.json
+++ b/i18n/de.json
@@ -146,7 +146,7 @@
     "dgc-windows-wallet-modal-dogecoin-core-pro": "Allerdings hat dies im Nachhinein einige Vorteile. Es ist sicher, mit dieser Brieftasche Dogecoin \"abzubauen\", da sie die M&ouml;glichkeit hat, die Transaktionen aus Auszahlungen zu verarbeiten. Dogecoin Core hilft au&szlig;erdem dabei, das Dogecoin-Netzwerk am Leben zu erhalten.",
     "dgc-osx-wallet-modal-dogecoin-core": "Dogecoin Core.",
     "dgc-android-wallet-modal-title": "VON GOOGLE PLAY HERUNTERLADEN.",
-    "dgc-android-wallet-modal-apk": "<a href=\"https://github.com/langerhans/dogecoin-wallet-new/releases/download/1.08/wallet-1.08-aligned.apk\">Direkter APK-Download.</a>",
+    "dgc-android-wallet-modal-apk": "Direkter APK-Download.",
     "dgc-ios-wallet-modal-title": "AUS DEM APP STORE HERUNTERLADEN.",
     "dgc-getting-started-title": "ERSTE SCHRITTE",
     "dgc-getting-started-desc": "Erste Schritte mit Dogecoin",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -148,7 +148,7 @@
     "dgc-windows-wallet-modal-dogecoin-core-pro": "But this comes at an advantage. It is safe to mine Dogecoin with this wallet, as it will be able to handle the transactions from payouts. It will also help maintain the Dogecoin network.", 
     "dgc-osx-wallet-modal-dogecoin-core": "Dogecoin Core.", 
 	"dgc-android-wallet-modal-title": "DOWNLOAD FROM GOOGLE PLAY.",
-    "dgc-android-wallet-modal-apk": "<a href=\"https://github.com/langerhans/dogecoin-wallet-new/releases/download/1.08/wallet-1.08-aligned.apk\">Direct APK Download.</a>",
+    "dgc-android-wallet-modal-apk": "Direct APK Download.",
 	"dgc-ios-wallet-modal-title": "DOWNLOAD FROM THE APP STORE.",
     "dgc-getting-started-title": "GETTING STARTED",
     "dgc-getting-started-desc": "Getting Started with Dogecoin",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -145,7 +145,7 @@
     "dgc-windows-wallet-modal-dogecoin-core-pro": "Pero también tiene sus ventajas. Es seguro minar Dogecoin con este monedero, ya que será capaz de manejar el volumen de transacciones de los pagos. Además, ayudará a mantener la red Dogecoin.", 
     "dgc-osx-wallet-modal-dogecoin-core": "Dogecoin Core.", 
 	"dgc-android-wallet-modal-title": "DESCARGA DESDE GOOGLE PLAY.",
-    "dgc-android-wallet-modal-apk": "<a href=\"https://github.com/langerhans/dogecoin-wallet-new/releases/download/1.08/wallet-1.08-aligned.apk\">Descarga el APK directamente.</a>",
+    "dgc-android-wallet-modal-apk": "Descarga el APK directamente.",
 	"dgc-ios-wallet-modal-title": "DESCARGA DESDE LA APP STORE.",
     "dgc-getting-started-title": "COMENZANDO",
     "dgc-getting-started-desc": "Comenzando con Dogecoin",

--- a/index.html
+++ b/index.html
@@ -493,11 +493,11 @@
 			<div class="modal-body text-center">
 				<h2 data-i18n="dgc-android-wallet-modal-title" class="modal-title dogefont">DOWNLOAD FROM GOOGLE PLAY.</h2>
 				<a href="https://play.google.com/store/apps/details?id=de.langerhans.wallet&utm_source=global_co&utm_medium=prtnr&utm_content=Mar2515&utm_campaign=PartBadge&pcampaignid=MKT-AC-global-none-all-co-pr-py-PartBadges-Oct1515-1" target="_blank">
-					<img class="badge-padding" style="height: 60px; width: 185px;" alt="Get it on Google Play" src="https://play.google.com/intl/en_us/badges/images/apps/en-play-badge.png" />
+					<img class="badge-padding" style="width: 185px;" alt="Get it on Google Play" src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" />
 				</a>
 				<br>
 				<h4 class="mobile-learn-padding" data-i18n="dgc-windows-wallet-modal-getting-started">Learn how to set up your wallet with the <a href="/getting-started" target="_blank">Getting Started Guide</a>.</h4>
-				<h5 class="android-apk-margin" data-i18n="dgc-android-wallet-modal-apk"><a href="https://github.com/langerhans/dogecoin-wallet-new/releases/download/1.08/wallet-1.08-aligned.apk">Direct APK Download.</a></h5>
+				<h5 class="android-apk-margin"><a data-i18n="dgc-android-wallet-modal-apk" href="https://github.com/langerhans/dogecoin-wallet-new/releases/download/4.0.0/wallet-4.0.0-prod-release.apk">Direct APK Download.</a></h5>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
- Update the "Direct APK download" link to the latest version [4.0.0](https://github.com/langerhans/dogecoin-wallet-new/releases/tag/4.0.0)
- Replace Play Store badge with newer image
- Translate the contents of the anchor tag instead of the entire element (happy to revert this if it was intentional)