### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,9 @@
 ---
 name: Bug Report
 about: You're experiencing an issue with Dogecoin.com.
+title: ""
+labels: bug
+assignees: ""
 ---
 
 <!--
@@ -8,10 +11,12 @@ about: You're experiencing an issue with Dogecoin.com.
 * Remove sections that do not apply.
 * This issue tracker is only for technical issues related to Dogecoin.com.
 * For general questions about Dogecoin.com please use one of the various communities, e.g. Reddit, IRC, Discord, etc.
+* Please search the existing issues for relevant bug reports, and use the [reaction feature](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to add upvotes to pre-existing reports.
 
 -->
 
 ### Describe the issue
+Tell us about the issue
 
 ### Can you reliably reproduce the issue?
 #### If so, please list the steps to reproduce below:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug Report
+about: You're experiencing an issue with Dogecoin.com.
+---
+
+<!--
+
+* Remove sections that do not apply.
+* This issue tracker is only for technical issues related to Dogecoin.com.
+* For general questions about Dogecoin.com please use one of the various communities, e.g. Reddit, IRC, Discord, etc.
+
+-->
+
+### Describe the issue
+
+### Can you reliably reproduce the issue?
+#### If so, please list the steps to reproduce below:
+1.
+2.
+3.
+
+### Expected behaviour
+Tell us what should happen
+
+### Actual behaviour
+Tell us what happens instead
+
+### Screenshots.
+If the issue is related to the website, screenshots can be added to this issue via drag & drop.
+
+### Environment
+- OS:
+- Browser:
+
+### Any extra information that might be useful in the debugging process.
+This is normally the contents of the [developer console](https://javascript.info/devtools). Raw text or a link to a [pastebin](https://pastebin.com/) type site are preferred.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,28 @@
+---
+name: Feature Request
+about: If you have something you think Dogecoin.com could improve or add support for.
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+<!--
+
+* Remove sections that do not apply.
+* This issue tracker is only for technical issues related to Dogecoin.com.
+* For general questions about Dogecoin.com please use one of the various communities, e.g. Reddit, IRC, Discord, etc.
+* Please search the existing issues for relevant feature requests, and use the [reaction feature](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to add upvotes to pre-existing requests.
+
+-->
+
+### Feature Description
+A written overview of the feature.
+
+### Use Case(s)
+Any relevant use-cases that you see.
+
+### Alternatives
+A clear and concise description of any alternative solutions or features you've considered.
+
+### Additional Context
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,18 @@
-## Description
+### Description
 <!-- Describe your changes in detail -->
 
-## Motivation and Context
+### Motivation and Context
 <!-- Why is this change required? What problem does it solve? -->
 <!-- If it fixes an open issue, please link to the issue here. -->
 
-## How Has This Been Tested?
+### How Has This Been Tested?
 <!-- Please describe in detail how you tested your changes. -->
 <!-- Include details of your testing environment, tests ran to see how -->
 <!-- your change affects other areas of the code, etc. -->
 
-## Screenshots (if appropriate):
+### Screenshots (if appropriate):
 
-## Checklist:
+### Checklist:
 <!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 - [ ] GitHub issue linked

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Description
+<!-- Describe your changes in detail -->
+
+## Motivation and Context
+<!-- Why is this change required? What problem does it solve? -->
+<!-- If it fixes an open issue, please link to the issue here. -->
+
+## How Has This Been Tested?
+<!-- Please describe in detail how you tested your changes. -->
+<!-- Include details of your testing environment, tests ran to see how -->
+<!-- your change affects other areas of the code, etc. -->
+
+## Screenshots (if appropriate):
+
+## Checklist:
+<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] GitHub issue linked
+- [ ] The necessary translations have been added for all languages
+- [ ] Any documentation has been updated accordingly
+- [ ] Responsive sizes (Mobile) tested
+- [ ] Cross Browser tested if necessary
+- [ ] Conflicts resolved


### PR DESCRIPTION
This PR adds issue templates. To better triage incoming issues or pull requests, these templates should provide others with the appropriate context needed to evaluate them and give feedback.

Are there others that should be added?
- [ ] ~Question~
- [x] Bug 
- [x] Feature Request
- [x] Pull Request