### PR TITLE
Tune docker guide run params

### DIFF
--- a/getting-started/contribute_docker.md
+++ b/getting-started/contribute_docker.md
@@ -11,7 +11,7 @@ We will build and run a docker container that will serve our website (index.html
 2. `cd dogecoin.com`
 3. Install [Docker](https://www.docker.com/products/docker-desktop)
 4. Build/tag the image, `docker build -t dogecoin.com:latest ./_contrib/docker/`
-5. Run, `docker run -p 0.0.0.0:5000:5000 --mount type=bind,source="$(pwd)",target=/code dogecoin.com:latest`
+5. Run, `docker run -d --rm -p 0.0.0.0:5000:5000 --mount type=bind,source="$(pwd)",target=/code dogecoin.com:latest`
   - the container exposes port 5000, so we must map host port to container port
   - bind our root dir (host), to `/code/` dir (container), to pick up changes to files for live reload
 6. Visit `localhost:5000` in your browser ( or `127.0.0.1:5000`)


### PR DESCRIPTION
### Description

Tune the `docker run` command in the Docker guide.

- Run as daemon to not lock down the terminal interactively
- Automagically remove the container when stopped

### Motivation and Context

- Saves a locked down terminal. Logs can always be streamed with docker logs -f
- Reduces overhead from having many stopped containers (i.e. self-clean things)
