### PR TITLE
Update homepage image with alt attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,7 +211,7 @@
             <!-- Portfolio Grid Items-->
             <div class="row justify-content-center">
                 <div class="col-md-4 col-sm-6 mt-5">
-                    <img style="width:100%;" src="assets/img/dogecoin_mobilewallet.png">
+                    <img style="width:100%;" src="assets/img/dogecoin_mobilewallet.png" alt="Dogecoin Mobile Wallet">
                 </div>
                 <div class="col-md-8 col-sm-6 mt-4">
                  <p class="lead">1. <span data-i18n="dgc-choose-wallet">Pick a Wallet</span></p>


### PR DESCRIPTION
img/dogecoin_mobilewallet.png failed to have an alt attribute

### Description
I created an alt attribute for the mobile wallet image.
This should improve the site's accessibility rating.


### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/25023814/117548469-337aac00-b003-11eb-887b-c14bf80a33e7.png)



### Checklist:
- [x] Any documentation has been updated accordingly
- [x] Responsive sizes (Mobile) tested
- [x] Cross Browser tested if necessary
- [x] Conflicts resolved
