### PR TITLE
Docs - Adding markdown to allow the links to open in a new tab.

### DIFF
--- a/getting-started/contribute_windows.md
+++ b/getting-started/contribute_windows.md
@@ -7,7 +7,7 @@ Before you start, you will need a webserver. The most common webservers are **Ap
 
 We'll use XAMPP (**X** **A**pache **M**ySQL **P**HP **P**erl) in this guide.
 
-First go to [apachefriends.org](https://apachefriends.org) and download XAMPP.
+First go to [apachefriends.org](https://apachefriends.org){target="_blank"} and download XAMPP.
 
 ![Screenshot](https://i.imgur.com/661Em5t.jpg)
 
@@ -17,7 +17,7 @@ Start the Apache webserver:
 
 ![Screenshot](https://i.imgur.com/rRq2cpv.png)
 
-Now open a browser and go to [http://localhost](http://localhost) or http://127.0.0.1
+Now open a browser and go to [http://localhost](http://localhost){target="_blank"} or http://127.0.0.1
 
 If you see something like this, everything is ready:
 
@@ -32,6 +32,6 @@ Extract the archive to `C:\xampp\htdocs\` and rename the folder `dogecoin.com-gh
 
 ## Step 3: Happy Coding :)
 
-Now you have a working copy of [dogecoin.com](https://dogecoin.com) at [http://127.0.0.1/dogecoin](http://127.0.0.1/dogecoin).
+Now you have a working copy of [dogecoin.com](https://dogecoin.com){target="_blank"} at [http://127.0.0.1/dogecoin](http://127.0.0.1/dogecoin){target="_blank"}.
 
 Just point your favourite IDE or Editor to `C:\xampp\htdocs\dogecoin\`  and start editing.


### PR DESCRIPTION
### Description
Added the necessary markdown to open the links in a new tab for the Windows version of the documentation. 

### Motivation and Context
It just is distracting to lose your place when you click a link that redirects the current page. So I've fixed that in the documentation.

### How Has This Been Tested?
Tested each of the "{target="_blank"}" link fixes manually for the page.

### Screenshots (if appropriate):
Shouldn't be needed for this type of change.

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] GitHub issue linked
- [ ] The necessary translations have been added for all languages
- [x] Any documentation has been updated accordingly
- [ ] Responsive sizes (Mobile) tested
- [ ] Cross Browser tested if necessary
- [X] Conflicts resolved
