### PR TITLE
fix the issue of "Android Wallet" heading malformed

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -264,5 +264,6 @@
     "dgc-wallets": "Wallets",     
     "dgc-get-some": "Get Some Dogecoin",
     "dgc-language": "Language",
-    "dgc-back-to-main": "Back to Main Page"
+    "dgc-back-to-main": "Back to Main Page",
+    "dgc-android-wallet": "Android Wallet"
 }


### PR DESCRIPTION
### Description
a fix for the issue of "Android Wallet" heading malformed #197
https://github.com/dogecoin/dogecoin.com/issues/197

the issue was caused by a new data-i18n entry, dgc-android-wallet, added to id.json but didn't add to en.json 

### How Has This Been Tested?
1. added "dgc-android-wallet" to en.json 
2. tested from my local, both chrome and safari

### Screenshots (if appropriate):

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] GitHub issue linked
- [ ] The necessary translations have been added for all languages
- [ ] Any documentation has been updated accordingly
- [ ] Responsive sizes (Mobile) tested
- [x] Cross Browser tested if necessary
- [ ] Conflicts resolved
