### PR TITLE
Suggestion to name small Dogecoin fractions.

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,6 +68,8 @@
             <div class="row">
                 <div class="col-md-12 text-center">
                     <h2 class="text-secondary"><span id="curPrice_DOGE">1 Dogecoin =</span> <div id="priceHolder"><span class="curPrice_USD">1 Dogecoin</span></div></h2>
+                    <h2 class="text-secondary">also <div id="priceHolder"><span class="curPrice_USD">1000 Dogebars</span></div></h2>
+                    <h2 class="text-secondary">also <div id="priceHolder"><span class="curPrice_USD">1000000 Dogediamonds</span></div></h2>
                 </div>
                 <div class="col-md-12">
                     <img class="masthead-avatar mb-1" style="margin-top:-3rem;" src="assets/img/doge.png" alt="" />


### PR DESCRIPTION
### Description
Suggestion to name small Dogecoin fractions.

### Motivation and Context
The current value of a Dogecoin is so high that fractions are often needed to describe useful values.
I did not found a 'official' way to describe Dogecoin values under 1 that are not fraction values.
A approach like the Bitcoin satoshi would be to small thats why I suggest to use two naming steps:

* Dogebar (like goldbar) for 0.001 Dogecoin
* Dogediamonds (like diamonds) for 0.000001 Dogecoin

For smaller values can the metric system naming be used: 0.00000001 = 1 Dogediamondcent

Another benifit would be, that every Dogecoin owner will  also be a (Dogediamonds) millionaire ;-).

It would definitely a good think to define names that can be used, this both names are just my suggestion.

I hope that a Pull Request is okay. I was unsure how to start this topic.

Best Regards