### PR TITLE
fix: inconsistent language dropdown on support page [#235]

### DIFF
--- a/support.html
+++ b/support.html
@@ -155,13 +155,24 @@
             </div>
             <!-- Footer About Text-->
             <div class="col-lg-4">
-                <p class="lead" data-i18n="dgc-language">Language</p>
-                <a class="text-white select-lang" style="cursor: pointer;" data-lang="en">English</a><br>
-                <a class="text-white select-lang" style="cursor: pointer;" data-lang="de">Deutsch</a><br>
-                <a class="text-white select-lang" style="cursor: pointer;" data-lang="fr">Français</a><br>
-                <a class="text-white select-lang" style="cursor: pointer;" data-lang="es">Español</a><br>
-                <a class="text-white select-lang" style="cursor: pointer;" data-lang="kn">Kannada</a><br>
-                <a class="text-white select-lang" style="cursor: pointer;" data-lang="ru">Русский</a><br>
+                <div class="dropdown">
+                  <a class="btn btn-lg btn-outline-light dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    <span data-i18n="dgc-language">Language</span>
+                  </a>
+                  <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
+                      <li><a class="dropdown-item select-lang" data-lang="en">English</a></li>
+                      <li><a class="dropdown-item select-lang" data-lang="de">Deutsch</a></li>
+                      <li><a class="dropdown-item select-lang" data-lang="es">Español</a></li>
+                      <li><a class="dropdown-item select-lang" data-lang="fr">Français</a></li>
+                      <li><a class="dropdown-item select-lang" data-lang="it">Italiano</a></li>
+                      <li><a class="dropdown-item select-lang" data-lang="hi">Hindi</a></li>
+                      <li><a class="dropdown-item select-lang" data-lang="id">Bahasa Indonesia</a></li>
+                      <li><a class="dropdown-item select-lang" data-lang="mr">Marathi</a></li>
+                      <li><a class="dropdown-item select-lang" data-lang="tr">Türkçe</a></li>
+                      <li><a class="dropdown-item select-lang" data-lang="kn">Kannada</a></li>
+                      <li><a class="dropdown-item select-lang" data-lang="ru">Русский</a></li>
+                  </div>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
### Description
See #235 

### Motivation and Context
Inconsistencies between support/index pages

### How Has This Been Tested?
N/A

### Screenshots (if appropriate):
<img width="755" alt="Screen Shot 2021-05-17 at 8 19 02 PM" src="https://user-images.githubusercontent.com/8783431/118586366-74836680-b74f-11eb-9ecc-4eb51b761cfb.png">


### Checklist:
- [x] GitHub issue linked
- [x] The necessary translations have been added for all languages
- [x] Any documentation has been updated accordingly
- [x] Responsive sizes (Mobile) tested
- [x] Cross Browser tested if necessary
- [x] Conflicts resolved
