### PR TITLE
Fix styling on OS buttons guide page mobile

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -62,6 +62,11 @@ h1, h2, h3, h4, h5, h6,
   justify-content: center;  
   align-items: center;  
 } 
+@media only screen and (min-device-width: 320px) and (max-device-width: 480px) {
+  .btn-holder .btn {
+    margin-bottom: 5px;
+  }
+}
 .scroll-to-top {  
   z-index: 1042;  
   right: 1rem;  


### PR DESCRIPTION
### Description
Noticed on my phone surfing on dogecoin.com that the OS buttons on the guide page is missing margin.

### Motivation and Context
It's just an UI fix to make it look better

### How Has This Been Tested?
Tested on mobile iPhone/Android

### Screenshots 
### Before
<img width="399" alt="Screenshot 2021-05-24 at 23 07 16" src="https://user-images.githubusercontent.com/32481745/119407876-289f6700-bce5-11eb-959c-46533a63fe3a.png">

###  After
<img width="398" alt="Screenshot 2021-05-24 at 23 06 56" src="https://user-images.githubusercontent.com/32481745/119407881-2a692a80-bce5-11eb-8ab3-a24a9bef2a42.png">
