### PR TITLE
changed wallet heading size and margin

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
                     <div class="col-md-6 col-lg-6 mb-5">
                         <div class="mx-auto">
                             <div class="img-holder">
-                                <p class="lead">Multidoge</p>
+                                <h4 class="mb-2 mt-2">Multidoge</h4>
                                 <img style="max-width: 150px;" src="assets/img/multidoge.png" alt="Multi doge logo">
                             </div>
                             <br>
@@ -114,7 +114,7 @@
                     </div>
                     <div class="col-md-6 col-lg-6 mb-5">
                         <div class="mx-auto">
-                            <p class="lead">Dogecoin Core</p>
+                            <h4 class="mb-2 mt-2">Dogecoin Core</h4>
                             <div class="img-holder">
                                 <img style="max-width: 150px;" src="assets/img/dogecoin-300.png" alt="Dogecoin core logo">
                             </div>
@@ -130,7 +130,7 @@
                     </div>
                     <div class="col-md-12 col-lg-12 mb-5">
                         <div class="mx-auto">
-                            <p class="lead" data-i18n="dgc-android-wallet">Android Wallet</p>
+                            <h4 class="mb-2 mt-2" data-i18n="dgc-android-wallet">Android Wallet</h4>
                             <a href="https://play.google.com/store/apps/details?id=de.langerhans.wallet&utm_source=global_co&utm_medium=prtnr&utm_content=Mar2515&utm_campaign=PartBadge&pcampaignid=MKT-AC-global-none-all-co-pr-py-PartBadges-Oct1515-1" target="_blank" class="img-holder" aria-label="Get it on Google Play">
                                 <img style="max-width: 150px;" src="assets/img/google_play.png" alt="">
                             </a>


### PR DESCRIPTION
### Description
Changed the wallets heading from p to h4 and added margin top and bottom; increased width size for "Get it on Google Play" button

### Motivation and Context
Displays the wallets more clearly

### How Has This Been Tested?
Worked fine on the Apache server I created on my virtual machine

### Screenshots (if appropriate):

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] GitHub issue linked
- [ ] The necessary translations have been added for all languages
- [ ] Any documentation has been updated accordingly
- [x] Responsive sizes (Mobile) tested
- [x] Cross Browser tested if necessary
- [x] Conflicts resolved
