### PR TITLE
Chnage simple "Dogecoin.com" text inyo Hyperlink Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Dogecoin.com
+# [Dogecoin.com]
 
 Dogecoin.com, for shibes and people everywhere.
 
 ![DogeCoin](http://static.tumblr.com/ppdj5y9/Ae9mxmxtp/300coin.png)
 
 ## What is this?
-It's the Dogecoin.com homepage. Made so everyone, even the nontechnical, can use Dogecoin.
+It's the [Dogecoin.com] homepage. Made so everyone, even the nontechnical, can use Dogecoin.
 Designed to retain the spirit of Dogecoin, whilst appealing to the more serious with its modern, simple design.
 
-Dogecoin.com is completely responsive, it'll look good on your smartphone, tablet, desktop, and more.
+[Dogecoin.com] is completely responsive, it'll look good on your smartphone, tablet, desktop, and more.
 It is completely HTML5 W3C Validated, which means it complies with the standards set by W3C.
 
 ## Technical Details Pls.
@@ -32,3 +32,5 @@ We created some guides just for you:
 [G2]: https://github.com/dogecoin/dogecoin.com/blob/gh-pages/getting-started/contribute_linux.md
 [G3]: https://github.com/dogecoin/dogecoin.com/blob/gh-pages/getting-started/contribute_osx.md
 [G4]: https://github.com/dogecoin/dogecoin.com/blob/gh-pages/getting-started/contribute_docker.md
+
+[Dogecoin.com]: https://dogecoin.com/


### PR DESCRIPTION
### Description
Change the simple "Dogecoin.com" text into a hyperlink, so that it will convenient for visitors to redirect to the website.

### Screenshots (if appropriate):
Before Changes:

![original](https://user-images.githubusercontent.com/51878265/132712048-de12a435-7b4b-4079-9fb6-d175dbcfbf4a.png)

After Changes:

![changes](https://user-images.githubusercontent.com/51878265/132712112-108cd301-46d4-482a-a119-e8dca22c6ba7.png)


### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] GitHub issue linked
- [x] The necessary translations have been added for all languages
- [x] Any documentation has been updated accordingly
- [x] Responsive sizes (Mobile) tested
- [x] Cross Browser tested if necessary
- [x ] Conflicts resolved
