### PR TITLE
update dogecoin core 1.14.6 release links

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,13 +120,13 @@
                                 <img style="max-width: 150px;" src="assets/img/dogecoin-300.png" alt="Dogecoin core logo">
                             </div>
                             <br>
-                            <a href="https://github.com/dogecoin/dogecoin/releases/download/v1.14.5/dogecoin-1.14.5-win32-setup-unsigned.exe" target="_blank" class="btn btn-md btn-info wallet-button mb-2"><span class="fab fa-windows"></span> <span> Windows 32-bit</span></a>
-                            <a href="https://github.com/dogecoin/dogecoin/releases/download/v1.14.5/dogecoin-1.14.5-win64-setup-unsigned.exe" target="_blank" class="btn btn-md btn-info wallet-button mb-2"><span class="fab fa-windows"></span> <span> Windows 64-bit</span></a>
+                            <a href="https://github.com/dogecoin/dogecoin/releases/download/v1.14.6/dogecoin-1.14.6-win32-setup-unsigned.exe" target="_blank" class="btn btn-md btn-info wallet-button mb-2"><span class="fab fa-windows"></span> <span> Windows 32-bit</span></a>
+                            <a href="https://github.com/dogecoin/dogecoin/releases/download/v1.14.6/dogecoin-1.14.6-win64-setup-unsigned.exe" target="_blank" class="btn btn-md btn-info wallet-button mb-2"><span class="fab fa-windows"></span> <span> Windows 64-bit</span></a>
                             <br>
-                            <a href="https://github.com/dogecoin/dogecoin/releases/download/v1.14.5/dogecoin-1.14.5-i686-pc-linux-gnu.tar.gz" target="_blank"  class="btn btn-md btn-success wallet-button mb-2"><span class="fab fa-linux"></span> <span> Linux 32-bit</span></a>
-                            <a href="https://github.com/dogecoin/dogecoin/releases/download/v1.14.5/dogecoin-1.14.5-x86_64-linux-gnu.tar.gz" target="_blank"  class="btn btn-md btn-success wallet-button mb-2"><span class="fab fa-linux"></span> <span> Linux 64-bit</span></a>
+                            <a href="https://github.com/dogecoin/dogecoin/releases/download/v1.14.6/dogecoin-1.14.6-i686-pc-linux-gnu.tar.gz" target="_blank"  class="btn btn-md btn-success wallet-button mb-2"><span class="fab fa-linux"></span> <span> Linux 32-bit</span></a>
+                            <a href="https://github.com/dogecoin/dogecoin/releases/download/v1.14.6/dogecoin-1.14.6-x86_64-linux-gnu.tar.gz" target="_blank"  class="btn btn-md btn-success wallet-button mb-2"><span class="fab fa-linux"></span> <span> Linux 64-bit</span></a>
                             <br>
-                            <a href="https://github.com/dogecoin/dogecoin/releases/download/v1.14.5/dogecoin-1.14.5-osx.dmg" target="_blank"  class="btn btn-md btn-secondary wallet-button"><span class="fab fa-apple"></span> <span data-i18n="dgc-wallet-osx"> macOS</span></a>
+                            <a href="https://github.com/dogecoin/dogecoin/releases/download/v1.14.6/dogecoin-1.14.6-osx-signed.dmg" target="_blank"  class="btn btn-md btn-secondary wallet-button"><span class="fab fa-apple"></span> <span data-i18n="dgc-wallet-osx"> macOS</span></a>
                         </div>
                     </div>
                     <div class="col-md-12 col-lg-12 mb-5">


### PR DESCRIPTION
multiple folks have notified me that shibes are attempting to download the new release here so updating.